### PR TITLE
Fix example setup in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,11 @@ $container = $app->getContainer();
 
 // Register Middleware
 $app->add(
-	new Polyglot(
-		// Available languages
-		[ 'en', 'fr', 'es' ],
-		// Fallback language
-		'fr',
+	new Polyglot([
+		'languages' => [ 'en', 'fr', 'es' ],
+		'fallbackLanguage' => 'fr',
 		// Hooks to call after language is resolved
-		[
+		'callbacks' => [
 			function ($language) use ($container) {
 				$container['environment']['language.current'] = $language;
 			},

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $app->add(
 			},
 			[ 'MySuperApp', 'set_language' ]
 		]
-	)
+	])
 );
 
 // Example route with ETag header


### PR DESCRIPTION
Holy balls it took me a long time to figure this out. Your example is no longer valid (assuming you changed the code after the example was valid). This is how it works, looking at the constructor of the Polyglot class. Thanks! 