### PR TITLE
Initialize callbacks as array - PHP 7.2 countable issue

### DIFF
--- a/src/Polyglot.php
+++ b/src/Polyglot.php
@@ -145,7 +145,7 @@ class Polyglot
      *
      * @var callable[]
      */
-    protected $callbacks;
+    protected $callbacks = [];
 
     /**
      * Supported languages


### PR DESCRIPTION
This is needed in order to properly work with PHP7.2 otherwise an exception is thrown.