### PR TITLE
Update dependency to resolve issues with php 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	"prefer-stable": true,
 	"require": {
 		"php": ">=5.5.0",
-		"willdurand/negotiation": "^2.0"
+		"willdurand/negotiation": "^3.0"
 	},
 	"require-dev": {
 		"slim/slim": "^3.0"


### PR DESCRIPTION
It turns out that the other package
uses a reserved keyword, thus
making it impossible to use it.